### PR TITLE
Workaround bug in SwiftShader

### DIFF
--- a/modules/canvaskit/canvaskit/package.json
+++ b/modules/canvaskit/canvaskit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluescape/canvaskit-wasm",
-  "version": "0.20.0-bluescape-2.3",
+  "version": "0.20.0-bluescape-2.4",
   "description": "A WASM version of Skia's Canvas API",
   "main": "bin/canvaskit.js",
   "homepage": "https://github.com/google/skia/tree/master/modules/canvaskit",

--- a/src/gpu/GrCaps.cpp
+++ b/src/gpu/GrCaps.cpp
@@ -82,6 +82,7 @@ GrCaps::GrCaps(const GrContextOptions& options) {
     fAvoidWritePixelsFastPath = false;
     fRequiresManualFBBarrierAfterTessellatedStencilDraw = false;
     fNativeDrawIndexedIndirectIsBroken = false;
+    fAvoidClearingFBOMipmapLevels = false;
 
     fPreferVRAMUseOverFlushes = true;
 

--- a/src/gpu/GrCaps.h
+++ b/src/gpu/GrCaps.h
@@ -366,6 +366,9 @@ public:
     // Many drivers have issues with color clears.
     bool performColorClearsAsDraws() const { return fPerformColorClearsAsDraws; }
 
+    // Google SwiftShader appears to have difficulty with this.
+    bool avoidClearingFBOMipmapLevels() const { return fAvoidClearingFBOMipmapLevels; }
+
     bool avoidLargeIndexBufferDraws() const { return fAvoidLargeIndexBufferDraws; }
 
     /// Adreno 4xx devices experience an issue when there are a large number of stencil clip bit
@@ -514,6 +517,7 @@ protected:
     bool fAvoidWritePixelsFastPath                   : 1;
     bool fRequiresManualFBBarrierAfterTessellatedStencilDraw : 1;
     bool fNativeDrawIndexedIndirectIsBroken          : 1;
+    bool fAvoidClearingFBOMipmapLevels               : 1;
 
     // ANGLE performance workaround
     bool fPreferVRAMUseOverFlushes                   : 1;

--- a/src/gpu/gl/GrGLCaps.cpp
+++ b/src/gpu/gl/GrGLCaps.cpp
@@ -8,6 +8,7 @@
 #include "src/gpu/gl/GrGLCaps.h"
 
 #include <memory>
+#include <stdio.h>
 
 #include "include/gpu/GrContextOptions.h"
 #include "src/core/SkCompressedDataUtils.h"
@@ -3568,6 +3569,11 @@ void GrGLCaps::applyDriverCorrectnessWorkarounds(const GrGLContextInfo& ctxInfo,
     if (fDriverBugWorkarounds.gl_clear_broken) {
         fPerformColorClearsAsDraws = true;
         fPerformStencilClearsAsDraws = true;
+    }
+
+    if (!GrGLGetWebGLRendererSupport(glInterface)) {
+        printf("CanvasKit detected software renderer\n");
+        fAvoidClearingFBOMipmapLevels = true;
     }
 
     if (ctxInfo.vendor() == kQualcomm_GrGLVendor) {

--- a/src/gpu/gl/GrGLDefines.h
+++ b/src/gpu/gl/GrGLDefines.h
@@ -1143,4 +1143,8 @@
 /* Tessellation */
 #define GR_GL_MAX_TESS_GEN_LEVEL_OES                        0x8E7E
 
+/* WEBGL_debug_renderer_info */
+#define GR_GL_UNMASKED_VENDOR_WEBGL                         0x9245
+#define GR_GL_UNMASKED_RENDERER_WEBGL                       0x9246
+
 #endif

--- a/src/gpu/gl/GrGLGpu.cpp
+++ b/src/gpu/gl/GrGLGpu.cpp
@@ -1335,7 +1335,8 @@ sk_sp<GrTexture> GrGLGpu::onCreateTexture(SkISize dimensions,
                 }
             }
         } else if (this->glCaps().canFormatBeFBOColorAttachment(format.asGLFormat()) &&
-                   !this->glCaps().performColorClearsAsDraws()) {
+                   !this->glCaps().performColorClearsAsDraws() &&
+                   !this->glCaps().avoidClearingFBOMipmapLevels()) {
             this->flushScissorTest(GrScissorTest::kDisabled);
             this->disableWindowRectangles();
             this->flushColorWrite(true);

--- a/src/gpu/gl/GrGLUtil.cpp
+++ b/src/gpu/gl/GrGLUtil.cpp
@@ -586,6 +586,18 @@ GrGLRenderer GrGLGetRenderer(const GrGLInterface* gl) {
     return GrGLGetRendererFromStrings((const char*)rendererString, gl->fExtensions);
 }
 
+bool GrGLGetWebGLRendererSupport(const GrGLInterface* gl) {
+    if (!gl->hasExtension("WEBGL_debug_renderer_info")) {
+        // If we can't get the renderer, then play it safe, because privacy mode could be on.
+        return false;
+    }
+    const GrGLubyte* rendererString;
+    GR_GL_CALL_RET(gl, rendererString, GetString(GR_GL_UNMASKED_RENDERER_WEBGL));
+    // Otherwise we only fail if the renderer is explicitly set to SwiftShader.
+    GrGLRenderer realRenderer = GrGLGetRendererFromStrings((const char*)rendererString, gl->fExtensions);
+    return (realRenderer != kGoogleSwiftShader_GrGLRenderer);
+}
+
 std::tuple<GrGLANGLEBackend, GrGLANGLEVendor, GrGLANGLERenderer> GrGLGetANGLEInfo(
         const GrGLInterface* gl) {
     const GrGLubyte* rendererString;

--- a/src/gpu/gl/GrGLUtil.h
+++ b/src/gpu/gl/GrGLUtil.h
@@ -249,6 +249,7 @@ GrGLVersion GrGLGetVersion(const GrGLInterface*);
 GrGLSLVersion GrGLGetGLSLVersion(const GrGLInterface*);
 GrGLVendor GrGLGetVendor(const GrGLInterface*);
 GrGLRenderer GrGLGetRenderer(const GrGLInterface*);
+bool GrGLGetWebGLRendererSupport(const GrGLInterface* gl);
 std::tuple<GrGLANGLEBackend, GrGLANGLEVendor, GrGLANGLERenderer> GrGLGetANGLEInfo(
         const GrGLInterface*);
 


### PR DESCRIPTION
When clearing all the mipmap levels of a texture, the
path that was generally taken was to bind it to a framebuffer
and clear the framebuffer. However, this causes all drawing to
fail with Google SwiftShader in WebGL - not sure why.
Instead, we detect the unmasked renderer string and check if it
is actually Google SwiftShader (or if it's masked and we can't tell).
If so, then we fall back to clearing the textures in a less efficient
way.

Also update the version from 2.3 to 2.4.