### PR TITLE
CORE-279: Set normal font hinting for skParagraph

### DIFF
--- a/modules/canvaskit/canvaskit/package.json
+++ b/modules/canvaskit/canvaskit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluescape/canvaskit-wasm",
-  "version": "0.20.0-bluescape-2.4",
+  "version": "0.20.0-bluescape-2.5",
   "description": "A WASM version of Skia's Canvas API",
   "main": "bin/canvaskit.js",
   "homepage": "https://github.com/google/skia/tree/master/modules/canvaskit",

--- a/modules/skparagraph/src/OneLineShaper.cpp
+++ b/modules/skparagraph/src/OneLineShaper.cpp
@@ -576,8 +576,17 @@ bool OneLineShaper::shape() {
                 // Create one more font to try
                 SkFont font(std::move(typeface), block.fStyle.getFontSize());
                 font.setEdging(SkFont::Edging::kAntiAlias);
-                font.setHinting(SkFontHinting::kSlight);
-                font.setSubpixel(true);
+                /*
+                 * Slight hinting is for subpixel rendering, but since we typically
+                 * render to texture, subpixel rendering is impossible. As a result,
+                 * we want normal hinting. TODO: Maybe expose this as a flag later.
+                 */
+                if (false /* can support subpixel */) {
+                    font.setHinting(SkFontHinting::kSlight);
+                    font.setSubpixel(true);
+                } else {
+                    font.setHinting(SkFontHinting::kNormal);
+                }
 
                 // Apply fake bold and/or italic settings to the font if the
                 // typeface's attributes do not match the intended font style.


### PR DESCRIPTION
By default, skParagraph expects subpixel antialiasing,
so it sets a lighter hinting mode in Freetext to allow
subpixel antialiasing to work. However, in our rendering
we always render to texture, so subpixel antialiasing
is useless to us, and the lighter hinting method shows
artifacts instead.

Update version from 2.4 to 2.5